### PR TITLE
Add: middleware for logging

### DIFF
--- a/myapi/api/middlewares/logging.go
+++ b/myapi/api/middlewares/logging.go
@@ -1,0 +1,41 @@
+package middlewares
+
+import (
+	"log"
+	"net/http"
+)
+
+/*
+Response Writer is an interface and the required methods are below.
+- Header
+- Write
+- WriteHeader
+Header method and Write method are delegated to the http.ResponseWriter.
+WriteHeader method is overrided to store the status code in the resLogging Writer struct.
+*/
+
+type resLoggingWriter struct {
+	http.ResponseWriter
+	code int
+}
+
+func NewResLoggingWriter(w http.ResponseWriter) *resLoggingWriter {
+	return &resLoggingWriter{ResponseWriter: w, code: http.StatusOK}
+}
+
+// 　override WriteHeader method
+func (rlw *resLoggingWriter) WriteHeader(code int) {
+	rlw.code = code
+	rlw.ResponseWriter.WriteHeader(code)
+}
+
+func LoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		log.Println(req.RequestURI, req.Method)
+
+		rlw := NewResLoggingWriter(w)
+		next.ServeHTTP(rlw, req)
+
+		log.Println("res: ", rlw.code)
+	})
+}

--- a/myapi/api/router.go
+++ b/myapi/api/router.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"net/http"
 
+	"github.com/Danchitomoo/go_api_learning/api/middlewares"
 	"github.com/Danchitomoo/go_api_learning/controllers"
 	"github.com/Danchitomoo/go_api_learning/services"
 	"github.com/gorilla/mux"
@@ -12,7 +13,7 @@ import (
 func NewRouter(db *sql.DB) *mux.Router {
 	ser := services.NewMyAppService(db)
 
-	aCon := controllers.NewAppController(ser)
+	aCon := controllers.NewArticleController(ser)
 	cCon := controllers.NewCommentController(ser)
 
 	r := mux.NewRouter()
@@ -24,6 +25,8 @@ func NewRouter(db *sql.DB) *mux.Router {
 	r.HandleFunc("/article/nice", aCon.PostNiceHandler).Methods(http.MethodPost)
 
 	r.HandleFunc("/comment", cCon.PostCommentHandler).Methods(http.MethodPost)
+
+	r.Use(middlewares.LoggingMiddleware)
 
 	return r
 }


### PR DESCRIPTION
# 概要
ログを出力するためのミドルウェアを実装＆導入した
# 学んだこと
- routingの際にミドルウェアを噛ませることで、容易に導入できる。
- すべての処理に導入する場合には`mix.Use`を使用することで、非常に手軽に導入可能。
- `http.ResponseWriter`はインターフェースであるため、カスタマイズ可能（`http.Request`などは構造体なのでだめ）
- 今回のように、あるインターフェース（構造体でも）のフィールドに型のみを指定すると、名前も自動で同一に設定される。さらに、メソッドが委譲される。（今回だと、`Header`と`Writer`は定義していないが、`http.ResponseWriter`のものが自動的に使われる）
- overrideすることも可能