### PR TITLE
refactor: make GetArticleService parallel processing

### DIFF
--- a/myapi/services/article_service.go
+++ b/myapi/services/article_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"database/sql"
 	"errors"
+	"sync"
 
 	"github.com/Danchitomoo/go_api_learning/apperrors"
 	"github.com/Danchitomoo/go_api_learning/models"
@@ -10,19 +11,43 @@ import (
 )
 
 func (s MyAppService) GetArticleService(articleID int) (models.Article, error) {
-	article, err := repositories.SelectArticleDetail(s.db, articleID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			err = apperrors.NAData.Wrap(err, "no data")
+	var article models.Article
+	var commentList []models.Comment
+	var articleGetErr, commentGetErr error
+
+	var amu sync.Mutex
+	var cmu sync.Mutex
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func(db *sql.DB, articleID int) {
+		defer wg.Done()
+		amu.Lock()
+		article, articleGetErr = repositories.SelectArticleDetail(db, articleID)
+		amu.Unlock()
+	}(s.db, articleID)
+
+	go func(db *sql.DB, articleID int) {
+		defer wg.Done()
+		cmu.Lock()
+		commentList, commentGetErr = repositories.SelectCommentList(db, articleID)
+		cmu.Unlock()
+	}(s.db, articleID)
+
+	wg.Wait()
+
+	if articleGetErr != nil {
+		if errors.Is(articleGetErr, sql.ErrNoRows) {
+			err := apperrors.NAData.Wrap(articleGetErr, "no data")
 			return models.Article{}, err
 		}
-		err = apperrors.GetDataFailed.Wrap(err, "fail to get data")
+		err := apperrors.GetDataFailed.Wrap(articleGetErr, "fail to get data")
 		return models.Article{}, err
 	}
 
-	commentList, err := repositories.SelectCommentList(s.db, articleID)
-	if err != nil {
-		err = apperrors.GetDataFailed.Wrap(err, "fail to get data")
+	if commentGetErr != nil {
+		err := apperrors.GetDataFailed.Wrap(commentGetErr, "fail to get data")
 		return models.Article{}, err
 	}
 	article.CommentList = append(article.CommentList, commentList...)

--- a/myapi/services/article_service_test.go
+++ b/myapi/services/article_service_test.go
@@ -1,0 +1,44 @@
+package services_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/Danchitomoo/go_api_learning/services"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var aSer *services.MyAppService
+
+func TestMain(m *testing.M) {
+	dbUser := "docker"
+	dbPassword := "docker"
+	dbDatabase := "sampledb"
+	dbConn := fmt.Sprintf("%s:%s@tcp(127.0.0.1:3306)/%s?parseTime=true", dbUser, dbPassword, dbDatabase)
+
+	db, err := sql.Open("mysql", dbConn)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	aSer = services.NewMyAppService(db)
+
+	m.Run()
+}
+
+func BenchmarkGetArticleService(b *testing.B) {
+	articleID := 1
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := aSer.GetArticleService(articleID)
+		if err != nil {
+			b.Error(err)
+			break
+		}
+	}
+}


### PR DESCRIPTION
# 概要
GetArticleServiceで行われている`repositories.SelectArticleDetail`と`repositories.SelectCommentList`が並行に処理されるようにした。
# 学んだこと
- `sync.Mutex`によるロック
- `sync.WaitGroup`による待ち合わせ