### PR TITLE
Refactor: install trackID in the context of http.request

### DIFF
--- a/myapi/api/middlewares/logging.go
+++ b/myapi/api/middlewares/logging.go
@@ -31,11 +31,15 @@ func (rlw *resLoggingWriter) WriteHeader(code int) {
 
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		log.Println(req.RequestURI, req.Method)
+		traceID := newTraceID()
 
+		log.Printf("[%d]%s %s \n", traceID, req.RequestURI, req.Method)
+
+		ctx := setTraceID(req.Context(), traceID)
+		req = req.WithContext(ctx)
 		rlw := NewResLoggingWriter(w)
 		next.ServeHTTP(rlw, req)
 
-		log.Println("res: ", rlw.code)
+		log.Printf("[%d]res: [%d]", traceID, rlw.code)
 	})
 }

--- a/myapi/api/middlewares/traceID.go
+++ b/myapi/api/middlewares/traceID.go
@@ -1,0 +1,37 @@
+package middlewares
+
+import (
+	"context"
+	"sync"
+)
+
+var (
+	logNo int = 1
+	mu    sync.Mutex
+)
+
+func newTraceID() int {
+	var no int
+
+	mu.Lock()
+	no = logNo
+	logNo += 1
+	mu.Unlock()
+
+	return no
+}
+
+type traceIDKey struct{}
+
+func setTraceID(ctx context.Context, traceID int) context.Context {
+	return context.WithValue(ctx, traceIDKey{}, traceID)
+}
+
+func GetTraceID(ctx context.Context) int {
+	id := ctx.Value(traceIDKey{})
+
+	if idInt, ok := id.(int); ok {
+		return idInt
+	}
+	return 0
+}

--- a/myapi/apperrors/errorHandler.go
+++ b/myapi/apperrors/errorHandler.go
@@ -3,7 +3,10 @@ package apperrors
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
+
+	"github.com/Danchitomoo/go_api_learning/api/middlewares"
 )
 
 func ErrorHandler(w http.ResponseWriter, req *http.Request, err error) {
@@ -15,6 +18,10 @@ func ErrorHandler(w http.ResponseWriter, req *http.Request, err error) {
 			Err:     err,
 		}
 	}
+
+	traceID := middlewares.GetTraceID(req.Context())
+	log.Printf("[%d]error: %s\n", traceID, appErr)
+
 	var statusCode int
 	switch appErr.ErrCode {
 	case NAData:


### PR DESCRIPTION
# 概要
track IDを導入した。
# 詳細
複数リクエストが来た場合、go routineで並列に処理される。
エラーが起きた場合などに、ログにその旨が表示されるが、どのgo routineのものなのか分からない。
そこで、go routineごとにユニークなtrack IDを付与し、識別できるようにした。
ミドルウェアとして導入。http.Request のcontext fieldを使う。
# 学んだこと
- `context.Context`はkey-valueの形で情報を保存する
- http.Requestにはcontext fieldが存在する（このように構造体のfieldにcontextを保存するのはアンチパターンで、http.Requestでは後方互換性維持のために特例で認められている。構造体の中に隠れていると見つけづらいため、明示的に直接引数として渡すことが推奨される）
- contextは直接変更を加えることはできず、構造体のメソッド経由でのみset/getできる